### PR TITLE
Fix BBC World News

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.world.news.live" name="World News Live" version="1.4" provider-name="K3oni | moneymaker | andre_pl">
+<addon id="plugin.video.world.news.live" name="World News Live" version="1.4.0.1" provider-name="K3oni | moneymaker | andre_pl">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.beautifulsoup" version="3.2.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+1.4.0.1 - Fix BBC World News
+
 1.4 - Fix RT, Sky News, NDTV, Arirang
 
 1.3.8.9 - Remove ProTV and UT, add Digi24, fix France 24

--- a/channels.py
+++ b/channels.py
@@ -244,7 +244,7 @@ class BBCNEWS(BaseChannel):
     def action_list_streams(self):
         data = {}
         data.update(self.args)
-	data.update({'action': 'play_stream', 'Title': 'BBC World', 'stream_url': 'http://wpc.C1A9.edgecastcdn.net/hls-live/20C1A9/bbc_world/ls_satlink/b_,264,528,828,.m3u8'})
+	data.update({'action': 'play_stream', 'Title': 'BBC World', 'stream_url': 'http://c004.p105.edgesuite.net/i/c004/bbcworld_1@97498/master.m3u8'})
 	self.plugin.add_list_item(data, is_folder=False)
 	data.update({'action': 'play_stream', 'Title': 'BBC Arabic', 'stream_url': 'http://wpc.C1A9.edgecastcdn.net/hls-live/20C1A9/bbc_ar/ls_satlink/b_,264,528,828,.m3u8'})
         self.plugin.add_list_item(data, is_folder=False)


### PR DESCRIPTION
The URL for BBC World recently stopped working, so this updates it with a working one harvested from the web.
